### PR TITLE
explicit Python 3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ classifiers = [
   'Development Status :: 5 - Production/Stable',
   'Intended Audience :: Developers',
   'Programming Language :: Python',
+  'Programming Language :: Python 3',
   'Operating System :: OS Independent',
   'Natural Language :: English',
   'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ classifiers = [
   'Development Status :: 5 - Production/Stable',
   'Intended Audience :: Developers',
   'Programming Language :: Python',
-  'Programming Language :: Python 3',
+  'Programming Language :: Python :: 3',
   'Operating System :: OS Independent',
   'Natural Language :: English',
   'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
- Can I Use Python 3 lists this package as a [blocker](https://caniusepython3.com/project/iniherit) for PY3, however, PY3 tests pass
- There seems to be a discrepancy between the [README.rst](https://github.com/cadithealth/iniherit/blob/master/README.rst#installation) which mentions that PY3 users need to install `distribute`, though the requirement was removed from [setup.py](https://github.com/cadithealth/iniherit/commit/79902c639f517b646b8ef57e9bd381f476d74f14)
  - If PY3 users no longer need `distribute` I will remove it from `README.rst`
  - Otherwise, [logic can be added](http://stackoverflow.com/a/33451105) so that in `setup.py` PY3 users install `distribute`
